### PR TITLE
Prevents a user that belongs to a franchise from writing reviews.

### DIFF
--- a/client/js/drawModule.js
+++ b/client/js/drawModule.js
@@ -330,10 +330,28 @@ var drawModule = (function() {
   }
 
   function addCreateReviewLink(restaurantName) {
-    var userInfo = JSON.parse(localStorage.getItem('userInfo'));
+    var userInfo = connectionsAPI.getUser();
 
+    // only end users can write reviews
     if (! connectionsAPI.hasRole(userInfo,
       connectionsAPI.role.endUser)) {
+      return null;
+    }
+
+    // franchise managers can't write reviews
+    if ( connectionsAPI.hasRole(userInfo,
+      connectionsAPI.role.franchiseManager)) {
+      return null;
+    }
+
+    // global managers can't write reviews
+    if ( connectionsAPI.hasRole(userInfo,
+      connectionsAPI.role.globalManager)) {
+      return null;
+    }
+
+    // franchise employees can't write reviews
+    if ( userInfo.organizations.length > 0) {
       return null;
     }
 

--- a/client/js/drawModule.js
+++ b/client/js/drawModule.js
@@ -333,25 +333,25 @@ var drawModule = (function() {
     var userInfo = connectionsAPI.getUser();
 
     // only end users can write reviews
-    if (! connectionsAPI.hasRole(userInfo,
+    if (!connectionsAPI.hasRole(userInfo,
       connectionsAPI.role.endUser)) {
       return null;
     }
 
     // franchise managers can't write reviews
-    if ( connectionsAPI.hasRole(userInfo,
+    if (connectionsAPI.hasRole(userInfo,
       connectionsAPI.role.franchiseManager)) {
       return null;
     }
 
     // global managers can't write reviews
-    if ( connectionsAPI.hasRole(userInfo,
+    if (connectionsAPI.hasRole(userInfo,
       connectionsAPI.role.globalManager)) {
       return null;
     }
 
     // franchise employees can't write reviews
-    if ( userInfo.organizations.length > 0) {
+    if (userInfo.organizations.length > 0) {
       return null;
     }
 


### PR DESCRIPTION
As requested in #138 this PR prevents a user that belongs to a franchise from writing reviews.

Previously we only checked if a user had the "End user" role. 

We have also inspected the actual user information and we get:

```
            organizations           roles

user1       Franchise1              "End user"
user2       Franchise2              "End user"
user3       Franchise3              "End user"
user4       Franchise4              "End user"
user5                               "End user"
user6                               "End user"
user7                               "End user"
user8                               "End user"
user9                               "End user"
user0                               "Gobal Manager" "End user"
```

Due to the actual user information, we have considered the next cases:
- User has the role "Franchise Manager".
- User has the role  "Global Manager".
- User has organizations.
